### PR TITLE
make readability more portable

### DIFF
--- a/lib/Readability.inc.php
+++ b/lib/Readability.inc.php
@@ -242,7 +242,7 @@ class Readability {
         // 多个数据，以数组的形式返回
         return Array(
             'title'   => $ContentTitle ? $ContentTitle->nodeValue : "",
-            'content' => mb_convert_encoding($Target->saveHTML(), DOM_DEFAULT_CHARSET, "HTML-ENTITIES")
+            'content' => mb_convert_encoding($Target->saveHTML(), Readability::DOM_DEFAULT_CHARSET, "HTML-ENTITIES")
         );
     }
 


### PR DESCRIPTION
如果單獨使用 lib/Readability.inc.php 的 class
會有 undefined constant 的錯誤訊息。
