### PR TITLE
改进获取封面大图的类方法

### DIFF
--- a/lib/Readability.inc.php
+++ b/lib/Readability.inc.php
@@ -243,9 +243,19 @@ class Readability {
     public function getLeadImageUrl($node) {
         $images = $node->getElementsByTagName("img");
 
-        if ($images->length && $leadImage = $images->item(0)) {
-            return $leadImage->getAttribute("src");
-        }
+        if ($images->length){
+			$i = 0;
+			while($leadImage = $images->item($i++)) {
+				$imgsrc = $leadImage->getAttribute("src");
+				$imgdatasrc = $leadImage->getAttribute("data-src");
+				$imgsrclast =  $imgsrc ? $imgsrc : $imgdatasrc;
+				list($img['width'],$img['height'])=getimagesize($imgsrclast);
+				if($img['width'] > 150 && $img['height'] >150){
+					return $imgsrclast;
+				}
+				
+			}
+		}
 
         return null;
     }


### PR DESCRIPTION
实际生产环境中，发现获取封面大图时获取到了多小尺寸很小的“图标”性质的图片。
改进获取封面大图的类方法，之后可以把一些小图标和小头像之类“图标”性质的图片过滤掉。要么不显示图片，要么显示正文中的尺寸稍大的图片。
